### PR TITLE
Improve semiautomatic tracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.mastodon</groupId>
 	<artifactId>mastodon-tracking</artifactId>
-	<version>1.0.0-beta-20-SNAPSHOT</version>
+	<version>1.0.0-beta-20</version>
 
 	<name>Mastodon Tracking</name>
 	<description>Basic tracking algorithms based on Mastodon data structures.</description>
@@ -115,7 +115,7 @@
 	<scm>
 		<connection>scm:git:https:github.com/mastodon-sc/mastodon-tracking</connection>
 		<developerConnection>scm:git:git@github.com:mastodon-sc/mastodon-tracking</developerConnection>
-		<tag>HEAD</tag>
+		<tag>mastodon-tracking-1.0.0-beta-20</tag>
 		<url>https://github.com/mastodon-sc/mastodon-tracking</url>
 	</scm>
 	<issueManagement>

--- a/release.properties
+++ b/release.properties
@@ -1,0 +1,28 @@
+#release configuration
+#Sun Jan 26 13:26:57 CET 2025
+project.dev.org.mastodon\:mastodon-tracking=1.0.0-beta-21-SNAPSHOT
+project.rel.org.mastodon\:mastodon-tracking=1.0.0-beta-20
+scm.commentPrefix=[maven-release-plugin] 
+exec.pomFileName=pom.xml
+pushChanges=false
+releaseStrategyId=default
+projectVersionPolicyConfig=<projectVersionPolicyConfig>${projectVersionPolicyConfig}</projectVersionPolicyConfig>\n
+scm.tag=mastodon-tracking-1.0.0-beta-20
+remoteTagging=true
+project.scm.org.mastodon\:mastodon-tracking.developerConnection=scm\:git\:git@github.com\:mastodon-sc/mastodon-tracking
+exec.additionalArguments=-Dgpg.skip\=true 
+scm.branchCommitComment=@{prefix} prepare branch @{releaseLabel}
+projectVersionPolicyId=default
+scm.url=scm\:git\:https\://github.com/mastodon-sc/mastodon-tracking
+scm.tagNameFormat=@{project.artifactId}-@{project.version}
+pinExternals=false
+preparationGoals=clean verify
+project.scm.org.mastodon\:mastodon-tracking.tag=HEAD
+scm.releaseCommitComment=@{prefix} prepare release @{releaseLabel}
+exec.snapshotReleasePluginAllowed=false
+exec.activateProfiles=deploy-to-scijava
+scm.developmentCommitComment=@{prefix} prepare for next development iteration
+project.scm.org.mastodon\:mastodon-tracking.url=https\://github.com/mastodon-sc/mastodon-tracking
+project.scm.org.mastodon\:mastodon-tracking.connection=scm\:git\:https\:github.com/mastodon-sc/mastodon-tracking
+scm.rollbackCommitComment=@{prefix} rollback the release of @{releaseLabel}
+completedPhase=end-release

--- a/src/main/java/org/mastodon/tracking/detection/DoGDetectorOp.java
+++ b/src/main/java/org/mastodon/tracking/detection/DoGDetectorOp.java
@@ -211,6 +211,11 @@ public class DoGDetectorOp
 			dog.setExecutorService( threadService.getExecutorService() );
 			final ArrayList< RefinedPeak< Point > > refinedPeaks = dog.getSubpixelPeaks();
 
+			if( refinedPeaks.size() == 0 ) {
+				final ArrayList< Point > peaks = dog.getPeaks();
+				peaks.stream().forEach( p -> refinedPeaks.add( new RefinedPeak< Point >( p, p, 0, false ) ));
+			}
+
 			final double[] pos = new double[ 3 ];
 			final RealPoint sp = RealPoint.wrap( pos );
 			final RealPoint p3d = new RealPoint( 3 );


### PR DESCRIPTION
This PR introduces a backup option for detecting a target spot.
With the current implementation, DogDetectorOp uses getSubpixelPeaks(), which often fails to detect peaks.
With this PR, it uses getPeaks() when getSubpixelPeaks() fails.