### PR TITLE
Update mastodon 35 and pomscijava 42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+        <version>42.0.0</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>
@@ -134,8 +134,8 @@
 		<license.projectName>mastodon-tracking</license.projectName>
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
-		
-		<mastodon.version>1.0.0-beta-34</mastodon.version>
+
+        <mastodon.version>1.0.0-beta-35</mastodon.version>
 		
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/test/java/org/mastodon/tracking/StartImageJ.java
+++ b/src/test/java/org/mastodon/tracking/StartImageJ.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * mastodon-pasteur
+ * %%
+ * Copyright (C) 2019 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.tracking;
+
+import java.lang.invoke.MethodHandles;
+
+import org.scijava.Context;
+import org.scijava.ui.UIService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shows the ImageJ main window, with Mastodon installed.
+ *
+ * @author Stefan Hahmann
+ */
+public class StartImageJ
+{
+	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	public static void main( String... args )
+	{
+		logger.info( "Starting ImageJ..." );
+		Context context = new Context();
+		UIService uiService = context.service( UIService.class );
+		uiService.showUI();
+	}
+}


### PR DESCRIPTION
This pull request updates project dependencies and versioning in the `pom.xml` file, and adds a new utility class for launching the ImageJ UI with Mastodon installed.

* Updated the parent POM version in `pom.xml` from `40.0.0` to `42.0.0`, ensuring compatibility with the latest SciJava build infrastructure.
* Bumped the `mastodon.version` property in `pom.xml` from `1.0.0-beta-34` to `1.0.0-beta-35`, reflecting the next release iteration.

New utility class:

* Added `StartImageJ.java` in `src/test/java/org/mastodon/tracking/`, which provides a main method to launch the ImageJ UI with Mastodon installed, aiding development and testing.